### PR TITLE
Hotfix

### DIFF
--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/api/IHotelService.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/api/IHotelService.java
@@ -1,10 +1,7 @@
 package com.imatia.campusdual.grupoun_bootcampbackend.api;
 
 import com.imatia.campusdual.grupoun_bootcampbackend.model.dto.HotelDTO;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.HotelAlreadyExistsException;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.HotelDoesNotExistException;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.InvalidFloorNumberException;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.InvalidNumberOfFloorsException;
+import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.*;
 
 import java.util.List;
 
@@ -14,7 +11,7 @@ public interface IHotelService {
 
     List<HotelDTO> queryAll();
 
-    int insertHotel(HotelDTO hotelDTO) throws HotelAlreadyExistsException, InvalidNumberOfFloorsException;
+    int insertHotel(HotelDTO hotelDTO) throws HotelAlreadyExistsException, InvalidNumberOfFloorsException, InvalidHotelNameException;
 
     int updateHotel(HotelDTO hotelDTO) throws HotelDoesNotExistException, InvalidFloorNumberException, IllegalStateException;
 

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/api/IRoomService.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/api/IRoomService.java
@@ -15,7 +15,7 @@ public interface IRoomService {
 
     int insertRoom(RoomDTO roomDTO) throws InvalidAssignedHotelException, InvalidRoomNumberException;
 
-    int deleteRoom(RoomDTO roomDTO);
+    int deleteRoom(RoomDTO roomDTO) throws RoomDoesNotExistException;
 
     boolean roomExistsById(RoomDTO roomDTO);
 

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/HotelController.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/HotelController.java
@@ -2,10 +2,7 @@ package com.imatia.campusdual.grupoun_bootcampbackend.controller;
 
 import com.imatia.campusdual.grupoun_bootcampbackend.api.IHotelService;
 import com.imatia.campusdual.grupoun_bootcampbackend.model.dto.HotelDTO;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.HotelAlreadyExistsException;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.HotelDoesNotExistException;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.InvalidFloorNumberException;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.InvalidNumberOfFloorsException;
+import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +23,7 @@ public class HotelController {
 
         try {
             insertedId = hotelService.insertHotel(hotelDTO);
-        } catch (HotelAlreadyExistsException | InvalidNumberOfFloorsException e) {
+        } catch (HotelAlreadyExistsException | InvalidNumberOfFloorsException | InvalidHotelNameException e) {
             HashMap<String, String> response = new HashMap<>();
             response.put("error", e.getMessage());
             return new ResponseEntity<>(response, HttpStatus.CONFLICT);
@@ -55,6 +52,7 @@ public class HotelController {
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
     @PutMapping(value="/update")
     public
     ResponseEntity<Map<String,?>>updateHotel(@RequestBody HotelDTO hotelDTO){

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/HotelController.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/HotelController.java
@@ -54,8 +54,7 @@ public class HotelController {
     }
 
     @PutMapping(value="/update")
-    public
-    ResponseEntity<Map<String,?>>updateHotel(@RequestBody HotelDTO hotelDTO){
+    public ResponseEntity<Map<String,?>>updateHotel(@RequestBody HotelDTO hotelDTO){
         int updatedHotelId;
         try {
             updatedHotelId = hotelService.updateHotel(hotelDTO);

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/HotelController.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/HotelController.java
@@ -53,8 +53,8 @@ public class HotelController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @PutMapping(value="/update")
-    public ResponseEntity<Map<String,?>>updateHotel(@RequestBody HotelDTO hotelDTO){
+    @PutMapping(value = "/update")
+    public ResponseEntity<Map<String, ?>> updateHotel(@RequestBody HotelDTO hotelDTO) {
         int updatedHotelId;
         try {
             updatedHotelId = hotelService.updateHotel(hotelDTO);
@@ -69,8 +69,8 @@ public class HotelController {
 
             return new ResponseEntity<>(response, HttpStatus.CONFLICT);
         }
-        HashMap<String,Integer>response = new HashMap<>();
-        response.put("updatedHotelId",updatedHotelId);
+        HashMap<String, Integer> response = new HashMap<>();
+        response.put("updatedHotelId", updatedHotelId);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/RoomController.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/RoomController.java
@@ -42,7 +42,9 @@ public class RoomController {
             Map<String, Integer> responseBody = new HashMap<>();
             responseBody.put("deletedId", roomService.deleteRoom(roomDTO));
             return new ResponseEntity<>(responseBody, HttpStatus.OK);
-        } catch (Exception e) {
+        } catch (RoomDoesNotExistException e) {
+            Map<String, String> responseBody = new HashMap<>();
+            responseBody.put("error", e.getMessage());
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
     }

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/RoomController.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/controller/RoomController.java
@@ -45,7 +45,7 @@ public class RoomController {
         } catch (RoomDoesNotExistException e) {
             Map<String, String> responseBody = new HashMap<>();
             responseBody.put("error", e.getMessage());
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/model/dao/HotelDAO.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/model/dao/HotelDAO.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HotelDAO extends JpaRepository<Hotel, Integer> {
+    boolean existsByNameIgnoreCase(String name);
 }

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/HotelService.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/HotelService.java
@@ -5,10 +5,7 @@ import com.imatia.campusdual.grupoun_bootcampbackend.model.dao.HotelDAO;
 import com.imatia.campusdual.grupoun_bootcampbackend.model.dto.HotelDTO;
 import com.imatia.campusdual.grupoun_bootcampbackend.model.dto.dtomapper.HotelMapper;
 import com.imatia.campusdual.grupoun_bootcampbackend.model.entity.Hotel;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.HotelAlreadyExistsException;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.HotelDoesNotExistException;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.InvalidFloorNumberException;
-import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.InvalidNumberOfFloorsException;
+import com.imatia.campusdual.grupoun_bootcampbackend.service.exception.*;
 import com.imatia.campusdual.grupoun_bootcampbackend.util.RoomUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -40,10 +37,12 @@ public class HotelService implements IHotelService {
     }
 
     @Override
-    public int insertHotel(HotelDTO hotelDTO) throws HotelAlreadyExistsException, InvalidNumberOfFloorsException {
-        List<HotelDTO> allHotelDTOs = queryAll();
+    public int insertHotel(HotelDTO hotelDTO) throws HotelAlreadyExistsException, InvalidNumberOfFloorsException, InvalidHotelNameException {
+        if (hotelDTO.getName() == null || hotelDTO.getName().isEmpty()) {
+            throw new InvalidHotelNameException("A non-empty hotel name must be provided");
+        }
 
-        if (allHotelDTOs.stream().anyMatch(dto -> dto.getName().equals(hotelDTO.getName()))) {
+        if (hotelDAO.existsByNameIgnoreCase(hotelDTO.getName())) {
             throw new HotelAlreadyExistsException("This hotel already exists");
         }
 

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/HotelService.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/HotelService.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 
 @Service("HotelService")
@@ -90,7 +91,9 @@ public class HotelService implements IHotelService {
 
     @Override
     public int deleteHotel(HotelDTO hotelDTO) throws HotelDoesNotExistException {
-        if (queryHotel(hotelDTO) == null) {
+        try {
+            queryHotel(hotelDTO);
+        } catch (EntityNotFoundException e) {
             throw new HotelDoesNotExistException("Hotel not found");
         }
 

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/RoomService.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/RoomService.java
@@ -37,7 +37,7 @@ public class RoomService implements IRoomService {
         this.roomUtils = roomUtils;
     }
 
-    public boolean validateRoomNumber(RoomDTO roomDTO, int numberOfFloors){
+    public boolean validateRoomNumber(RoomDTO roomDTO, int numberOfFloors) {
 
         return roomDTO.getRoomNumber() >= FIRST_ROOM_NUMBER &&
                 roomDTO.getRoomNumber() <= 999 &&
@@ -59,7 +59,7 @@ public class RoomService implements IRoomService {
         assignedHotelDTO = hotelService.queryHotel(assignedHotelDTO);
         if (
                 !validateRoomNumber(roomDTO, assignedHotelDTO.getNumberOfFloors()) ||
-                        roomDAO.existsByRoomNumberAndHotel_Id(roomDTO.getRoomNumber(),assignedHotelId)
+                        roomDAO.existsByRoomNumberAndHotel_Id(roomDTO.getRoomNumber(), assignedHotelId)
         ) {
             throw new InvalidRoomNumberException("Cannot create room with this number");
         }
@@ -97,22 +97,15 @@ public class RoomService implements IRoomService {
 
     @Override
     public int updateRoom(RoomDTO roomDTO) throws InvalidRoomNumberException, InvalidAssignedHotelException, RoomDoesNotExistException {
+        Room room = roomDAO
+                .findById(roomDTO.getId()).orElseThrow(() -> new RoomDoesNotExistException("This room does not exist"));
 
-        Room room;
-        try {
-            room = roomDAO.getReferenceById(roomDTO.getId());
-            if (!validateRoomNumber(roomDTO,room.getHotel().getNumberOfFloors())){
-                throw new InvalidRoomNumberException("Cannot update room with this number");
-            }
-            room.setRoomNumber(roomDTO.getRoomNumber());
-        } catch (EntityNotFoundException e) {
-            throw new RoomDoesNotExistException("This room does not exist");
+        if (!validateRoomNumber(roomDTO, room.getHotel().getNumberOfFloors())) {
+            throw new InvalidRoomNumberException("Cannot update room with this number");
         }
+        room.setRoomNumber(roomDTO.getRoomNumber());
 
-        roomDAO.saveAndFlush(room);
-
-        return room.getId();
-
+        return roomDAO.saveAndFlush(room).getId();
     }
 
 }

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/RoomService.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/RoomService.java
@@ -72,9 +72,12 @@ public class RoomService implements IRoomService {
     }
 
     @Override
-    public int deleteRoom(RoomDTO roomDTO) {
-        Room room = roomMapper.toEntity(roomDTO);
-        roomDAO.delete(room);
+    public int deleteRoom(RoomDTO roomDTO) throws RoomDoesNotExistException {
+        if (!roomDAO.existsById(roomDTO.getId())) {
+            throw new RoomDoesNotExistException("A room with this id could not be found");
+        }
+
+        roomDAO.deleteById(roomDTO.getId());
         return roomDTO.getId();
     }
 

--- a/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/exception/InvalidHotelNameException.java
+++ b/src/main/java/com/imatia/campusdual/grupoun_bootcampbackend/service/exception/InvalidHotelNameException.java
@@ -1,0 +1,7 @@
+package com.imatia.campusdual.grupoun_bootcampbackend.service.exception;
+
+public class InvalidHotelNameException extends Exception {
+    public InvalidHotelNameException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Correción de erros varios:

- Eliminadas as chamadas a `getReferenceById` e substituídas por `findById` debido á que o primeiro método devolve un proxy de Hibernate que pode non estar inicializado.
- Engadidas validacións en métodos nos que non se realizaban.
- Corrixidos algúns erros de vulto.
- Corrixido o formato de algúns fragmentos.